### PR TITLE
A new flag and site-config option, to set the title/legend of the new-blog-entry form.

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -4,6 +4,7 @@
  */
 $conf['namespace']    = 'blog';       // default location for blog entries
 $conf['formposition'] = 'bottom';     // position of new entry form
+//$conf['newentrytitle'] = 'New Entry Here:';     // Title text for the 'new entry' form
 $conf['dateprefix']   = '';           // prefix date to new entry IDs
 $conf['sortkey']      = 'cdate';      // sort key for blog entries
 $conf['sortorder']    = 'descending'; // ascending or descending

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,6 +8,7 @@
 $meta['namespace']    = array('string');
 $meta['formposition'] = array('multichoice',
                          '_choices' => array('top', 'bottom', 'none'));
+$meta['newentrytitle'] = array('string');
 $meta['dateprefix']   = array('string');
 $meta['sortkey']      = array('multichoice',
                         '_choices' => array('cdate', 'mdate', 'pagename', 'id', 'title'));

--- a/helper.php
+++ b/helper.php
@@ -42,6 +42,12 @@ class helper_plugin_blog extends DokuWiki_Plugin {
                     'number (optional)' => 'integer'),
                 'return' => array('pages' => 'array'),
                 );
+        $result[] = array(
+                'name'   => 'getFlags',
+                'desc'   => 'get values for flags, or defaults where not supplied',
+                'params' => array('flags' => 'array'),
+                'return' => array('flags' => 'array'),
+                );
         return $result;
     }
 
@@ -121,6 +127,47 @@ class helper_plugin_blog extends DokuWiki_Plugin {
         if (is_numeric($num)) $result = array_slice($result, 0, $num);
 
         return $result;
+    }
+
+    /**
+     * Turn a list of user-supplied flags into a complete list of all flags
+     * required by the Blog plugin (not including those for the Include plugin),
+     * using global configuration options or plugin defaults where flags have
+     * not been supplied.
+     * 
+     * Currently handles 'formpos' and 'newentrytitle'.
+     * 
+     * @author Sam Wilson <sam@samwilson.id.au>
+     * @param array $setflags Flags that have been set by the user
+     * @return array All flags required by the Blog plugin (only)
+     */
+    function getFlags($setflags) {
+        $flags = array();
+
+        // Form Position
+        $flags['formpos'] = $this->getConf('formposition');
+        if(in_array('topform', $setflags)) {
+            $flags['formpos'] = 'top';
+        }elseif(in_array('bottomform', $setflags)) {
+            $flags['formpos'] = 'bottom';
+        }elseif(in_array('noform', $setflags)) {
+            $flags['formpos'] = 'none';
+        }
+
+        // New Entry Title
+        $newentrytitle = preg_grep('|newentrytitle=.*|', $setflags);
+        if (count($newentrytitle) > 0) {
+            $newentrytitle = array_pop(explode('=', array_pop($newentrytitle), 2));
+            if (!empty($newentrytitle)) {
+                $flags['newentrytitle'] = $newentrytitle;
+            }
+        } elseif ($conf_title = $this->getConf('newentrytitle')) {
+            $flags['newentrytitle'] = $conf_title;
+        } else {
+            $flags['newentrytitle'] = $this->getLang('newentry');
+        }
+
+        return $flags;
     }
 
     /**

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -13,6 +13,8 @@ $lang['formposition']           = 'position of the new entry form';
 $lang['formposition_o_top']     = 'top';
 $lang['formposition_o_bottom']  = 'bottom';
 
+$lang['newentrytitle']          = 'title of the new entry form';
+
 $lang['dateprefix']             = 'prefix date to new entry IDs';
 
 $lang['sortkey']                = 'sort blog entries by';

--- a/syntax/blog.php
+++ b/syntax/blog.php
@@ -18,6 +18,12 @@ require_once(DOKU_PLUGIN.'syntax.php');
 
 class syntax_plugin_blog_blog extends DokuWiki_Syntax_Plugin {
 
+    /** @var string The position of the new-entry form */
+    private $formpos;
+
+    /** @var string The text used for the title of the new-entry form */
+    private $newentrytitle;
+
     function getInfo() {
         return array(
                 'author' => 'Gina Häußge, Michael Klier, Esther Brunner',
@@ -82,20 +88,15 @@ class syntax_plugin_blog_blog extends DokuWiki_Syntax_Plugin {
             }
         }
 
-        // any create form overrides?
-        $formpos = $this->getConf('formposition');
-        if(in_array('topform',$flags)){
-            $formpos = 'top';
-        }elseif(in_array('bottomform',$flags)){
-            $formpos = 'bottom';
-        }elseif(in_array('noform',$flags)){
-            $formpos = 'none';
-        }
+        // Normalise flags
+        $blog_flags = $my->getFlags($flags);
+        $this->formpos = $blog_flags['formpos'];
+        $this->newentrytitle = $blog_flags['newentrytitle'];
 
         if (!$entries) {
             if ((auth_quickaclcheck($ns.':*') >= AUTH_CREATE) && ($mode == 'xhtml')) {
                 $renderer->info['cache'] = false;
-                if($formpos != 'none') $renderer->doc .= $this->_newEntryForm($ns);
+                if($this->formpos != 'none') $renderer->doc .= $this->_newEntryForm($ns);
             }
             return true; // nothing to display
         }
@@ -116,7 +117,7 @@ class syntax_plugin_blog_blog extends DokuWiki_Syntax_Plugin {
 
             // show new entry form
             $perm_create = (auth_quickaclcheck($ns.':*') >= AUTH_CREATE);
-            if ($perm_create && $formpos == 'top') {
+            if ($perm_create && $this->formpos == 'top') {
                 $renderer->doc .= $this->_newEntryForm($ns);
             }
 
@@ -158,7 +159,7 @@ class syntax_plugin_blog_blog extends DokuWiki_Syntax_Plugin {
             $renderer->doc .= $this->_browseEntriesLinks($more, $first, $num);
 
             // show new entry form
-            if ($perm_create && $formpos == 'bottom') {
+            if ($perm_create && $this->formpos == 'bottom') {
                 $renderer->doc .= $this->_newEntryForm($ns);
             }
         }
@@ -227,7 +228,7 @@ class syntax_plugin_blog_blog extends DokuWiki_Syntax_Plugin {
         return '<div class="newentry_form">'.DOKU_LF.
             '<form id="blog__newentry_form" method="post" action="'.script().'" accept-charset="'.$lang['encoding'].'">'.DOKU_LF.
             DOKU_TAB.'<fieldset>'.DOKU_LF.
-            DOKU_TAB.DOKU_TAB.'<legend>'.$this->getLang('newentry').'</legend>'.DOKU_LF.
+            DOKU_TAB.DOKU_TAB.'<legend>'.hsc($this->newentrytitle).'</legend>'.DOKU_LF.
             DOKU_TAB.DOKU_TAB.'<input type="hidden" name="id" value="'.$ID.'" />'.DOKU_LF.
             DOKU_TAB.DOKU_TAB.'<input type="hidden" name="do" value="newentry" />'.DOKU_LF.
             DOKU_TAB.DOKU_TAB.'<input type="hidden" name="ns" value="'.$ns.'" />'.DOKU_LF.


### PR DESCRIPTION
This adds a new flag to the blog syntax: `newentrytitle`

e.g. `{{blog>.?10&newentrytitle=New bulletin title:&topform&nofooter}}`

A couple of shortcomings:
1. The default (in whatever language) is not shown in the site config form (rather, this is blank unless customised); and
2. Ampersands cannot be used in the newentrytitle, because they are the flag delimiter.
