### PR TITLE
day list style

### DIFF
--- a/style.css
+++ b/style.css
@@ -38,3 +38,40 @@ img.blog_archive_bar {
   border: 0 none;
   vertical-align: bottom;
 }
+div.dokuwiki ul.blog {
+  list-style: none;
+  text-indent: -1.63em;
+  margin-left: 1.75em;
+}
+div.dokuwiki ul.blog li:before { margin-right:0.5em; }
+#blogd01:before { content: '01'; }
+#blogd02:before { content: '02'; }
+#blogd03:before { content: '03'; }
+#blogd04:before { content: '04'; }
+#blogd05:before { content: '05'; }
+#blogd06:before { content: '06'; }
+#blogd07:before { content: '07'; }
+#blogd08:before { content: '08'; }
+#blogd09:before { content: '09'; }
+#blogd10:before { content: '10'; }
+#blogd11:before { content: '11'; }
+#blogd12:before { content: '12'; }
+#blogd13:before { content: '13'; }
+#blogd14:before { content: '14'; }
+#blogd15:before { content: '15'; }
+#blogd16:before { content: '16'; }
+#blogd17:before { content: '17'; }
+#blogd18:before { content: '18'; }
+#blogd19:before { content: '19'; }
+#blogd20:before { content: '20'; }
+#blogd21:before { content: '21'; }
+#blogd22:before { content: '22'; }
+#blogd23:before { content: '23'; }
+#blogd24:before { content: '24'; }
+#blogd25:before { content: '25'; }
+#blogd26:before { content: '26'; }
+#blogd27:before { content: '27'; }
+#blogd28:before { content: '28'; }
+#blogd29:before { content: '29'; }
+#blogd30:before { content: '30'; }
+#blogd31:before { content: '31'; }

--- a/style.css
+++ b/style.css
@@ -38,12 +38,15 @@ img.blog_archive_bar {
   border: 0 none;
   vertical-align: bottom;
 }
+
 div.dokuwiki ul.blog {
   list-style: none;
   text-indent: -1.63em;
   margin-left: 1.75em;
 }
+
 div.dokuwiki ul.blog li:before { margin-right:0.5em; }
+
 #blogd01:before { content: '01'; }
 #blogd02:before { content: '02'; }
 #blogd03:before { content: '03'; }

--- a/syntax/archive.php
+++ b/syntax/archive.php
@@ -194,14 +194,14 @@ class syntax_plugin_blog_archive extends DokuWiki_Syntax_Plugin {
                     $list .= '</ul>' . DOKU_LF;
                 }
                 $current_month = date('m',$entry['date']);
-                $list .= '<h3 id="m' . date('o-m',$entry['date']) . '">' . $this->getLang('month_' . $current_month) . '</h3><ul>' . DOKU_LF;
+                $list .= '<h3 id="m' . date('o-m',$entry['date']) . '">' . $this->getLang('month_' . $current_month) . '</h3><ul class="blog">' . DOKU_LF;
                 $ul_open = true;
             }
             $histogram_count[date('o-m',$entry['date'])] += 1;
             if ($histogram_higher < $histogram_count[date('o-m',$entry['date'])]) {
                 $histogram_higher = $histogram_count[date('o-m',$entry['date'])];
             }
-            $list .= '<li>' . date('d',$entry['date']) . ' - <a href="' . wl($entry['id']) . '" title="' . $entry['id'] . '">' . $entry['title'] . '</a></li>' . DOKU_LF;
+            $list .= '<li id="blogd' . date('d',$entry['date']) . '"><a href="' . wl($entry['id']) . '" title="' . $entry['id'] . '">' . $entry['title'] . '</a></li>' . DOKU_LF;
         }
         $list .= '</ul>' . DOKU_LF;
 


### PR DESCRIPTION
Changed normal bullet list to a list with the day as `li before content`.

Tested with
- Ubuntu 16.04
  - FF 47
  - Chromium 50
- Android 5.1
  - FF 47
  - Chrome 51

Vertical alignment is not 100% accurate but much better than before.

Browser compatibility: http://www.w3schools.com/cssref/sel_before.asp

**old style**

![old](https://cloud.githubusercontent.com/assets/1454849/16343969/8315b488-3a3a-11e6-85fc-c1d772cda7f4.png)

**new style**

![new](https://cloud.githubusercontent.com/assets/1454849/16343979/8c8898e6-3a3a-11e6-8541-67074aca5f08.png)
