### PR TITLE
Allow the newer/older entries paging controls on blogs to be hidden

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -163,6 +163,9 @@ class helper_plugin_blog extends DokuWiki_Plugin {
             $flags['newentrytitle'] = $this->getLang('newentry');
         }
 
+        // Paging Controls
+        $flags['pagingcontrols'] = !in_array('nopagingcontrols', $setflags);
+
         return $flags;
     }
 

--- a/syntax/blog.php
+++ b/syntax/blog.php
@@ -76,9 +76,10 @@ class syntax_plugin_blog_blog extends DokuWiki_Syntax_Plugin {
         }
 
         // Normalise flags
-        $blog_flags    = $my->getFlags($flags);
-        $formpos       = $blog_flags['formpos'];
-        $newentrytitle = $blog_flags['newentrytitle'];
+        $blog_flags     = $my->getFlags($flags);
+        $formpos        = $blog_flags['formpos'];
+        $newentrytitle  = $blog_flags['newentrytitle'];
+        $pagingcontrols = $blog_flags['pagingcontrols'];
 
         if ($mode == 'xhtml') {
             // prevent caching to ensure the included pages are always fresh
@@ -149,7 +150,7 @@ class syntax_plugin_blog_blog extends DokuWiki_Syntax_Plugin {
             if ($clevel && !$include_flags['inline']) $renderer->doc .= '<div class="level'.$clevel.'">'.DOKU_LF;
 
             // show older / newer entries links
-            $renderer->doc .= $this->_browseEntriesLinks($more, $first, $num);
+            if ($pagingcontrols) $renderer->doc .= $this->_browseEntriesLinks($more, $first, $num);
 
             // show new entry form
             if ($perm_create && $formpos == 'bottom') {


### PR DESCRIPTION
This is useful if you just want to show the top n posts of a blog on a page.

Example:  This is used on www.binary-kitchen.de to just give a top 2 post overview of the kitchen log on the start page without giving the user the option to display older posts as those are available on a separate page.