### PR TITLE
Prevent Undefined array key 1 warnings

### DIFF
--- a/syntax/archive.php
+++ b/syntax/archive.php
@@ -24,10 +24,10 @@ class syntax_plugin_blog_archive extends DokuWiki_Syntax_Plugin {
         global $ID;
 
         $match = substr($match, 10, -2); // strip {{archive> from start and }} from end
-        list($match, $flags) = explode('&', $match, 2);
+        @list($match, $flags) = explode('&', $match, 2);
         $flags = explode('&', $flags);
-        list($match, $refine) = explode(' ', $match, 2);
-        list($ns, $rest) = explode('?', $match, 2);
+        @list($match, $refine) = explode(' ', $match, 2);
+        @list($ns, $rest) = explode('?', $match, 2);
 
         $author = NULL;
         foreach($flags as $i=>$flag) {

--- a/syntax/archive.php
+++ b/syntax/archive.php
@@ -24,10 +24,10 @@ class syntax_plugin_blog_archive extends DokuWiki_Syntax_Plugin {
         global $ID;
 
         $match = substr($match, 10, -2); // strip {{archive> from start and }} from end
-        @list($match, $flags) = explode('&', $match, 2);
+        list($match, $flags) = sexplode('&', $match, 2, '');
         $flags = explode('&', $flags);
-        @list($match, $refine) = explode(' ', $match, 2);
-        @list($ns, $rest) = explode('?', $match, 2);
+        list($match, $refine) = sexplode(' ', $match, 2, null);
+        list($ns, $rest) = sexplode('?', $match, 2, null);
 
         $author = NULL;
         foreach($flags as $i=>$flag) {


### PR DESCRIPTION
These warnings occur due to the incorrect assumption that `explode(…, $match, 2)` will return at least an array of length 2:
```
E_WARNING: Undefined array key 1
/var/www/dokuwiki/lib/plugins/blog/syntax/archive.php(29)
#0 /var/www/dokuwiki/lib/plugins/blog/syntax/archive.php(29): dokuwiki\ErrorHandler::errorHandler()
#1 /var/www/dokuwiki/inc/parser/handler.php(298): syntax_plugin_blog_archive->handle()
#2 /var/www/dokuwiki/inc/Parsing/Lexer/Lexer.php(269): Doku_Handler->plugin()
#3 /var/www/dokuwiki/inc/Parsing/Lexer/Lexer.php(196): dokuwiki\Parsing\Lexer\Lexer->invokeHandler()
#4 /var/www/dokuwiki/inc/Parsing/Lexer/Lexer.php(146): dokuwiki\Parsing\Lexer\Lexer->dispatchTokens()
#5 /var/www/dokuwiki/inc/Parsing/Parser.php(113): dokuwiki\Parsing\Lexer\Lexer->parse()
#6 /var/www/dokuwiki/inc/parserutils.php(234): dokuwiki\Parsing\Parser->parse()
#7 /var/www/dokuwiki/inc/parserutils.php(198): p_get_instructions()
#8 /var/www/dokuwiki/inc/parserutils.php(520): p_cached_instructions()
#9 /var/www/dokuwiki/inc/parserutils.php(299): p_render_metadata()
#10 /var/www/dokuwiki/inc/common.php(262): p_get_metadata()
#11 /var/www/dokuwiki/doku.php(101): pageinfo()
#12 {main}
```

Fix this by suppressing the warnings.

Note: Another fix might be to use the DokuWiki `sexplode()` function instead of `explode()`.